### PR TITLE
implement GetCalibrationState

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.7"
+version = "0.7.8"
 authors = [
     "Benjamin Bolte <ben@kscale.dev>",
     "Denys Bezmenov <denys@kscale.dev>",

--- a/kos-py/pykos/__init__.py
+++ b/kos-py/pykos/__init__.py
@@ -1,6 +1,6 @@
 """KOS Python client."""
 
-__version__ = "0.7.7"
+__version__ = "0.7.8"
 
 from . import services
 from .client import KOS

--- a/kos-py/pykos/services/imu.py
+++ b/kos-py/pykos/services/imu.py
@@ -128,3 +128,7 @@ class IMUServiceClient(AsyncClientBase):
             CalibrationMetadata: Metadata about the calibration operation.
         """
         return await self.stub.Calibrate(Empty())
+
+    async def get_calibration_state(self) -> imu_pb2.GetCalibrationStateResponse:
+        """Get the calibration state of the IMU."""
+        return await self.stub.GetCalibrationState(imu_pb2.GetCalibrationStateRequest())

--- a/kos-stub/src/imu.rs
+++ b/kos-stub/src/imu.rs
@@ -9,6 +9,7 @@ use kos::{
     },
     kos_proto::common::ActionResponse,
 };
+use std::collections::HashMap;
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -111,5 +112,9 @@ impl IMU for StubIMU {
             z: 0.0,
             error: None,
         })
+    }
+
+    async fn get_calibration_state(&self) -> Result<HashMap<String, i32>> {
+        Ok(HashMap::new())
     }
 }

--- a/kos/proto/kos/imu.proto
+++ b/kos/proto/kos/imu.proto
@@ -35,6 +35,8 @@ service IMUService {
 
     // Retrieves quaternion from the IMU.
     rpc GetQuaternion(google.protobuf.Empty) returns (QuaternionResponse);
+
+    rpc GetCalibrationState(GetCalibrationStateRequest) returns (GetCalibrationStateResponse);
 }
 
 // Response message containing IMU values.
@@ -105,4 +107,13 @@ message IMUAdvancedValuesResponse {
     optional double temp = 7; // Temperature in degrees Celsius
         
     kos.common.Error error = 8; // Error details if any
+}
+
+message GetCalibrationStateRequest {}
+
+// Response message for calibration state (generic / device agnostic)
+message GetCalibrationStateResponse {
+    // General-purpose key-value map for calibration state
+    map<string, int32> state = 1;
+    kos.common.Error error = 2;
 }

--- a/kos/src/hal.rs
+++ b/kos/src/hal.rs
@@ -46,6 +46,7 @@ pub trait IMU: Send + Sync {
     ) -> Result<ActionResponse>;
     async fn get_euler(&self) -> Result<EulerAnglesResponse>;
     async fn get_quaternion(&self) -> Result<QuaternionResponse>;
+    async fn get_calibration_state(&self) -> Result<std::collections::HashMap<String, i32>>;
 }
 
 #[async_trait]

--- a/kos/src/services/imu.rs
+++ b/kos/src/services/imu.rs
@@ -146,4 +146,19 @@ impl ImuService for IMUServiceImpl {
 
         Ok(Response::new(quaternion))
     }
+
+    async fn get_calibration_state(
+        &self,
+        _request: Request<GetCalibrationStateRequest>,
+    ) -> Result<Response<GetCalibrationStateResponse>, Status> {
+        let state =
+            self.imu.get_calibration_state().await.map_err(|e| {
+                Status::internal(format!("Failed to get calibration state, {:?}", e))
+            })?;
+
+        Ok(Response::new(GetCalibrationStateResponse {
+            state,
+            error: None,
+        }))
+    }
 }


### PR DESCRIPTION
General Purpose Calibration State Request.

Example. bno055 continuously calibrates and provides status indication on the current state of calibration.

system (0-3)
acc (0-3)
gyro (0-3)
mag (0-3)

These values can be used as a confidence indication.